### PR TITLE
feat(gcs-bridge): add parsing of MAVLink packets

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -20,6 +20,7 @@
 idf_component_register(
 SRCS
     "main.c"
+    "gcs_bridge.c"
     "telemetry_bridge.c"
 INCLUDE_DIRS
     "."

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -38,4 +38,42 @@ menu "ARGUS Configuration"
                 can cause crash.
     endmenu
 
+    menu "GCS Configuration"
+        config ARGUS_GCS_UART_PORT_NUM
+            int "UART port number"
+            default 2
+            help
+                UART communication port number for the GCS. See UART
+                documentation for available port numbers.
+
+        config ARGUS_GCS_UART_BAUD_RATE
+            int "UART communication speed"
+            range 1200 921600
+            default 115200
+            help
+                UART communication speed for GCS.
+
+        config ARGUS_GCS_UART_RXD
+            int "UART RXD pin number"
+            default 2
+            help
+                GPIO number for UART RX pin. See UART documentation for more
+                information about available pin numbers for UART.
+
+        config ARGUS_GCS_UART_TXD
+            int "UART TXD pin number"
+            default 1
+            help
+                GPIO number for UART TX pin. See UART documentation for more
+                information about available pin numbers for UART.
+
+        config ARGUS_GCS_TASK_STACK_SIZE
+            int "GCS task stack size"
+            range 4196 16384
+            default 8192
+            help
+                Defines stack size for GCS Task. Insufficient stack size
+                can cause crash.
+    endmenu
+
 endmenu

--- a/main/gcs_bridge.c
+++ b/main/gcs_bridge.c
@@ -1,0 +1,58 @@
+/*
+ * This file is part of ARGUS Ground Station
+ * <https://github.com/nikolaptr/argus>.
+ *
+ * ARGUS Ground Station is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ARGUS Ground Station is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ARGUS Ground Station. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2025 Nikola Petrovic
+ * Contact: <nikolaptr6@gmail.com>
+ */
+
+#include "gcs_bridge.h"
+#include "driver/uart.h"
+#include "esp_log.h"
+
+/* GCS MAVLink channel - used for message parsing and message packing */
+#define ARGUS_GCS_MAV_CH MAVLINK_COMM_1
+
+void gcs_bridge(void *arg)
+{
+    mavlink_message_t mav_msg;       // MAVLink message.
+    uint8_t uart_rx[32];             // UART receive buffer.
+    char *tag = pcTaskGetName(NULL); // task name, used as tag.
+
+    for (;;) {
+        /* read data from UART */
+        int len = uart_read_bytes(CONFIG_ARGUS_GCS_UART_PORT_NUM, uart_rx,
+                                  sizeof(uart_rx), 10 / portTICK_PERIOD_MS);
+
+        /* error occurred during read */
+        if (len < 0)
+            continue;
+
+        /* parse read data */
+        for (int i = 0; i < len; i++) {
+            uint8_t status = 0;
+            status = mavlink_parse_char(ARGUS_GCS_MAV_CH, uart_rx[i], &mav_msg,
+                                        NULL);
+
+            /* no message could be decoded or bad CRC */
+            if (status != 1)
+                continue;
+
+            /* send message id to terminal */
+            ESP_LOGI(tag, "Received Message ID = %d", mav_msg.msgid);
+        }
+    }
+}

--- a/main/gcs_bridge.h
+++ b/main/gcs_bridge.h
@@ -1,0 +1,25 @@
+/*
+ * This file is part of ARGUS Ground Station
+ * <https://github.com/nikolaptr/argus>.
+ *
+ * ARGUS Ground Station is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ARGUS Ground Station is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ARGUS Ground Station. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2025 Nikola Petrovic
+ * Contact: <nikolaptr6@gmail.com>
+ */
+#include <stdio.h>
+
+#include "c_library_v2/all/mavlink.h"
+
+void gcs_bridge(void *arg);


### PR DESCRIPTION
This adds parsing of incoming Ground Control Station packets, such as QGroundControl or Mission Planner. Also, appropriate KConfig menu is added for Ground Control Station configuration.